### PR TITLE
Set default pin priority for apt

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -19,8 +19,10 @@
 # @param [String] package_ensure
 #   Determines the ensure state of the package.  Set to installed by default, but could be changed to latest.
 #
-# @param [Optional[Variant[Numeric, String]]] package_apt_pin
-#   Whether to pin the package to a particular source.
+# @param [Optional[Numeric]] package_apt_pin
+#   If set to a numeric value, pin the repo, with that value as the priority,
+#   (Debian/Ubuntu only). Default value is higher than the default (500) so
+#   that these packages take precedence over the default repos.
 #
 # @param [Boolean] manage_repo
 #   Whether or not this class should manage the erlang repository.
@@ -73,7 +75,7 @@
 class erlang (
   String  $package_name   = 'erlang',
   String  $package_ensure = 'installed',
-  Optional[Variant[Numeric, String]] $package_apt_pin = undef,
+  Numeric $package_apt_pin = 600,
   Boolean $manage_repo    = true,
   String  $repo_ensure    = 'present',
   Erlang::RepoSource $repo_source = 'packagecloud',

--- a/manifests/repo/apt/bintray.pp
+++ b/manifests/repo/apt/bintray.pp
@@ -1,13 +1,13 @@
 # erlang bintray apt repo
 class erlang::repo::apt::bintray (
-  String $ensure = $erlang::repo::apt::ensure,
-  String $location    = 'https://dl.bintray.com/rabbitmq-erlang/debian',
+  String $ensure     = $erlang::repo::apt::ensure,
+  String $location   = 'https://dl.bintray.com/rabbitmq-erlang/debian',
   # trusty, xenial, bionic, etc
-  String $release     = downcase($facts['os']['distro']['codename']),
-  String $repos       = 'erlang',
-  String $key         = '0A9AF2115F4687BD29803A206B73A36E6026DFCA',
-  String $key_source  = 'https://github.com/rabbitmq/signing-keys/releases/download/2.0/rabbitmq-release-signing-key.asc',
-  Optional[Variant[Numeric, String]] $pin = $erlang::package_apt_pin,
+  String $release    = downcase($facts['os']['distro']['codename']),
+  String $repos      = 'erlang',
+  String $key        = '0A9AF2115F4687BD29803A206B73A36E6026DFCA',
+  String $key_source = 'https://github.com/rabbitmq/signing-keys/releases/download/2.0/rabbitmq-release-signing-key.asc',
+  Numeric $pin       = $erlang::package_apt_pin,
 ) inherits erlang {
   apt::source { 'erlang-bintray':
     ensure   => $ensure,
@@ -21,7 +21,7 @@ class erlang::repo::apt::bintray (
   }
 
   if $pin {
-    apt::pin { 'erlang':
+    apt::pin { 'erlang-bintray':
       packages => '*',
       priority => $pin,
       origin   => inline_template('<%= require \'uri\'; URI(@location).host %>'),

--- a/manifests/repo/apt/erlang_solutions.pp
+++ b/manifests/repo/apt/erlang_solutions.pp
@@ -1,13 +1,13 @@
 # erlang erlang_solutions apt repo
 class erlang::repo::apt::erlang_solutions (
-  String $ensure = $erlang::repo::apt::ensure,
-  String $location    = 'https://packages.erlang-solutions.com/debian',
+  String $ensure     = $erlang::repo::apt::ensure,
+  String $location   = 'https://packages.erlang-solutions.com/debian',
   # trusty, xenial, bionic, etc
-  String $release     = downcase($facts['os']['distro']['codename']),
-  String $repos       = 'contrib',
-  String $key         = '434975BD900CCBE4F7EE1B1ED208507CA14F4FCA',
-  String $key_source  = 'https://packages.erlang-solutions.com/debian/erlang_solutions.asc',
-  Optional[Variant[Numeric, String]] $pin = $erlang::package_apt_pin,
+  String $release    = downcase($facts['os']['distro']['codename']),
+  String $repos      = 'contrib',
+  String $key        = '434975BD900CCBE4F7EE1B1ED208507CA14F4FCA',
+  String $key_source = 'https://packages.erlang-solutions.com/debian/erlang_solutions.asc',
+  Numeric $pin       = $erlang::package_apt_pin,
 ) inherits erlang {
   apt::source { 'erlang-erlang_solutions':
     ensure   => $ensure,
@@ -21,7 +21,7 @@ class erlang::repo::apt::erlang_solutions (
   }
 
   if $pin {
-    apt::pin { 'erlang':
+    apt::pin { 'erlang-erlang_solutions':
       packages => '*',
       priority => $pin,
       origin   => inline_template('<%= require \'uri\'; URI(@location).host %>'),

--- a/spec/acceptance/init_spec.rb
+++ b/spec/acceptance/init_spec.rb
@@ -3,9 +3,11 @@ require 'spec_helper_acceptance'
 describe 'erlang init:' do
   case fact('os.family')
   when 'RedHat'
+    pkg_cmd = 'yum info erlang | grep "^From repo"'
     default_repo_source = 'packagecloud'
     repo_source_list = %w[bintray erlang_solutions packagecloud]
   when 'Debian'
+    pkg_cmd = 'dpkg -s erlang | grep ^Maintainer'
     default_repo_source = 'bintray'
     repo_source_list = %w[bintray erlang_solutions]
   end
@@ -23,6 +25,10 @@ describe 'erlang init:' do
 
       describe package('erlang') do
         it { is_expected.to be_installed }
+        it 'comes from the expected source' do
+          pkg_output = shell(pkg_cmd)
+          expect(pkg_output.stdout).to include default_repo_source
+        end
       end
       describe yumrepo("erlang-#{default_repo_source}") do
         it { is_expected.to exist }
@@ -44,6 +50,10 @@ describe 'erlang init:' do
 
       describe package('erlang') do
         it { is_expected.not_to be_installed }
+        it 'comes from the expected source' do
+          pkg_output = shell(pkg_cmd)
+          expect(pkg_output.stdout).to include default_repo_source
+        end
       end
       describe yumrepo("erlang-#{default_repo_source}") do
         it { is_expected.not_to exist }
@@ -65,6 +75,10 @@ describe 'erlang init:' do
 
         describe package('erlang') do
           it { is_expected.to be_installed }
+          it 'comes from the expected source' do
+            pkg_output = shell(pkg_cmd)
+            expect(pkg_output.stdout).to include repo_source
+          end
         end
         describe yumrepo("erlang-#{repo_source}") do
           it { is_expected.to exist }
@@ -107,6 +121,10 @@ describe 'erlang init:' do
 
         describe package('erlang') do
           it { is_expected.not_to be_installed }
+          it 'comes from the expected source' do
+            pkg_output = shell(pkg_cmd)
+            expect(pkg_output.stdout).to include repo_source
+          end
         end
         describe yumrepo("erlang-#{default_repo_source}") do
           it { is_expected.not_to exist }
@@ -126,6 +144,10 @@ describe 'erlang init:' do
 
       describe package('erlang') do
         it { is_expected.to be_installed }
+        it 'comes from the expected source' do
+          pkg_output = shell(pkg_cmd)
+          expect(pkg_output.stdout).to include 'epel'
+        end
       end
       describe yumrepo('epel') do
         it { is_expected.to exist }
@@ -168,6 +190,10 @@ describe 'erlang init:' do
 
       describe package('erlang') do
         it { is_expected.to be_installed }
+        it 'comes from the expected source' do
+          pkg_output = shell(pkg_cmd)
+          expect(pkg_output.stdout).to include default_repo_source
+        end
       end
     end
 
@@ -183,6 +209,10 @@ describe 'erlang init:' do
 
         describe package('erlang') do
           it { is_expected.to be_installed }
+          it 'comes from the expected source' do
+            pkg_output = shell(pkg_cmd)
+            expect(pkg_output.stdout).to include repo_source
+          end
         end
       end
 

--- a/spec/classes/repo/apt/bintray_spec.rb
+++ b/spec/classes/repo/apt/bintray_spec.rb
@@ -21,6 +21,8 @@ describe 'erlang::repo::apt::bintray' do
                      'id'     => '0A9AF2115F4687BD29803A206B73A36E6026DFCA',
                      'source' => 'https://github.com/rabbitmq/signing-keys/releases/download/2.0/rabbitmq-release-signing-key.asc'
                    })
+            is_expected.to contain_apt__pin('erlang-bintray').
+              with('priority' => 600)
           end
         end
       end

--- a/spec/classes/repo/apt/erlang_solutions_spec.rb
+++ b/spec/classes/repo/apt/erlang_solutions_spec.rb
@@ -21,6 +21,8 @@ describe 'erlang::repo::apt::erlang_solutions' do
                      'id'     => '434975BD900CCBE4F7EE1B1ED208507CA14F4FCA',
                      'source' => 'https://packages.erlang-solutions.com/debian/erlang_solutions.asc'
                    })
+            is_expected.to contain_apt__pin('erlang-erlang_solutions').
+              with('priority' => 600)
           end
         end
       end


### PR DESCRIPTION
#### Pull Request (PR) description
It seems as if on some Debian distributions, the upstream package takes priority when the apt repo isn't pinned. Set the priority to 200, since this module configures and uses non-default repos