### PR TITLE
Drop EoL puppet 5 support; add Puppet 7

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,10 +1,8 @@
 ---
 # Fixtures file for puppet_spec_helper in the task: rake spec
 fixtures:
-  symlinks:
-    erlang: "#{source_dir}"
-  forge_modules:
-    apt: "puppetlabs/apt"
-    epel: "puppet/epel"
-    stdlib: "puppetlabs/stdlib"
-    yumrepo_core: "puppetlabs/yumrepo_core"
+  repositories:
+    apt: https://github.com/puppetlabs/puppetlabs-apt
+    epel: https://github.com/voxpupuli/puppet-epel
+    stdlib: https://github.com/puppetlabs/puppetlabs-stdlib
+    yumrepo_core: https://github.com/puppetlabs/puppetlabs-yumrepo_core

--- a/metadata.json
+++ b/metadata.json
@@ -48,7 +48,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 5.5.8 < 7.0.0"
+      "version_requirement": ">= 6.1.0 < 8.0.0"
     }
   ],
   "tags": [


### PR DESCRIPTION
this PR also contains https://github.com/voxpupuli/puppet-erlang/pull/5