### PR TITLE
Support for recent Ubuntu and Debian versions, stdlib 9.x and Puppet 8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@
 
 name: CI
 
-on: pull_request
+on: [pull_request, push]
 
 concurrency:
   group: ${{ github.ref_name }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@
 
 name: CI
 
-on: [pull_request, push]
+on: pull_request
 
 concurrency:
   group: ${{ github.ref_name }}

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -7,17 +7,17 @@
 ### Classes
 
 * [`erlang`](#erlang): Manages the Erlang repository and package installation.
-* [`erlang::repo`](#erlang--repo): Class that manages the erlang repo
-* [`erlang::repo::apt`](#erlang--repo--apt): erlang apt repo
-* [`erlang::repo::apt::erlang_solutions`](#erlang--repo--apt--erlang_solutions): erlang erlang_solutions apt repo
-* [`erlang::repo::yum`](#erlang--repo--yum): erlang yum repo
-* [`erlang::repo::yum::epel`](#erlang--repo--yum--epel): Erlang packagecloud yum repo
-* [`erlang::repo::yum::erlang_solutions`](#erlang--repo--yum--erlang_solutions): Erlang packagecloud yum repo
-* [`erlang::repo::yum::packagecloud`](#erlang--repo--yum--packagecloud): Erlang packagecloud yum repo
+* [`erlang::repo`](#erlangrepo): Class that manages the erlang repo
+* [`erlang::repo::apt`](#erlangrepoapt): erlang apt repo
+* [`erlang::repo::apt::erlang_solutions`](#erlangrepoapterlang_solutions): erlang erlang_solutions apt repo
+* [`erlang::repo::yum`](#erlangrepoyum): erlang yum repo
+* [`erlang::repo::yum::epel`](#erlangrepoyumepel): Erlang packagecloud yum repo
+* [`erlang::repo::yum::erlang_solutions`](#erlangrepoyumerlang_solutions): Erlang packagecloud yum repo
+* [`erlang::repo::yum::packagecloud`](#erlangrepoyumpackagecloud): Erlang packagecloud yum repo
 
 ### Data types
 
-* [`Erlang::RepoSource`](#Erlang--RepoSource): Options for what Erlang package repository to be configured on the system. This type defines the union of all possible options for both Apt a
+* [`Erlang::RepoSource`](#erlangreposource): Options for what Erlang package repository to be configured on the system. This type defines the union of all possible options for both Apt a
 
 ## Classes
 
@@ -73,14 +73,14 @@ class { 'erlang':
 
 The following parameters are available in the `erlang` class:
 
-* [`package_name`](#-erlang--package_name)
-* [`package_ensure`](#-erlang--package_ensure)
-* [`package_apt_pin`](#-erlang--package_apt_pin)
-* [`manage_repo`](#-erlang--manage_repo)
-* [`repo_ensure`](#-erlang--repo_ensure)
-* [`repo_source`](#-erlang--repo_source)
+* [`package_name`](#package_name)
+* [`package_ensure`](#package_ensure)
+* [`package_apt_pin`](#package_apt_pin)
+* [`manage_repo`](#manage_repo)
+* [`repo_ensure`](#repo_ensure)
+* [`repo_source`](#repo_source)
 
-##### <a name="-erlang--package_name"></a>`package_name`
+##### <a name="package_name"></a>`package_name`
 
 Data type: `String`
 
@@ -88,7 +88,7 @@ Name of the erlang package to install
 
 Default value: `'erlang'`
 
-##### <a name="-erlang--package_ensure"></a>`package_ensure`
+##### <a name="package_ensure"></a>`package_ensure`
 
 Data type: `String`
 
@@ -96,23 +96,23 @@ Determines the ensure state of the package.  Set to installed by default, but co
 
 Default value: `'installed'`
 
-##### <a name="-erlang--package_apt_pin"></a>`package_apt_pin`
+##### <a name="package_apt_pin"></a>`package_apt_pin`
 
 Data type: `Optional[Variant[Numeric, String]]`
 
 Whether to pin the package to a particular source.
 
-Default value: `undef`
+Default value: ``undef``
 
-##### <a name="-erlang--manage_repo"></a>`manage_repo`
+##### <a name="manage_repo"></a>`manage_repo`
 
 Data type: `Boolean`
 
 Whether or not this class should manage the erlang repository.
 
-Default value: `true`
+Default value: ``true``
 
-##### <a name="-erlang--repo_ensure"></a>`repo_ensure`
+##### <a name="repo_ensure"></a>`repo_ensure`
 
 Data type: `String`
 
@@ -120,7 +120,7 @@ Determines the ensure state of the repo.
 
 Default value: `'present'`
 
-##### <a name="-erlang--repo_source"></a>`repo_source`
+##### <a name="repo_source"></a>`repo_source`
 
 Data type: `Erlang::RepoSource`
 
@@ -135,11 +135,11 @@ For CentOS/RHEL the choices for `repo_source` are:
 
 Default value: `'packagecloud'`
 
-### <a name="erlang--repo"></a>`erlang::repo`
+### <a name="erlangrepo"></a>`erlang::repo`
 
 Class that manages the erlang repo
 
-### <a name="erlang--repo--apt"></a>`erlang::repo::apt`
+### <a name="erlangrepoapt"></a>`erlang::repo::apt`
 
 erlang apt repo
 
@@ -147,10 +147,10 @@ erlang apt repo
 
 The following parameters are available in the `erlang::repo::apt` class:
 
-* [`ensure`](#-erlang--repo--apt--ensure)
-* [`source`](#-erlang--repo--apt--source)
+* [`ensure`](#ensure)
+* [`source`](#source)
 
-##### <a name="-erlang--repo--apt--ensure"></a>`ensure`
+##### <a name="ensure"></a>`ensure`
 
 Data type: `String`
 
@@ -158,7 +158,7 @@ Data type: `String`
 
 Default value: `$erlang::repo_ensure`
 
-##### <a name="-erlang--repo--apt--source"></a>`source`
+##### <a name="source"></a>`source`
 
 Data type: `Erlang::RepoSource`
 
@@ -166,7 +166,7 @@ Data type: `Erlang::RepoSource`
 
 Default value: `$erlang::repo_source`
 
-### <a name="erlang--repo--apt--erlang_solutions"></a>`erlang::repo::apt::erlang_solutions`
+### <a name="erlangrepoapterlang_solutions"></a>`erlang::repo::apt::erlang_solutions`
 
 erlang erlang_solutions apt repo
 
@@ -174,15 +174,15 @@ erlang erlang_solutions apt repo
 
 The following parameters are available in the `erlang::repo::apt::erlang_solutions` class:
 
-* [`ensure`](#-erlang--repo--apt--erlang_solutions--ensure)
-* [`location`](#-erlang--repo--apt--erlang_solutions--location)
-* [`release`](#-erlang--repo--apt--erlang_solutions--release)
-* [`repos`](#-erlang--repo--apt--erlang_solutions--repos)
-* [`key`](#-erlang--repo--apt--erlang_solutions--key)
-* [`key_source`](#-erlang--repo--apt--erlang_solutions--key_source)
-* [`pin`](#-erlang--repo--apt--erlang_solutions--pin)
+* [`ensure`](#ensure)
+* [`location`](#location)
+* [`release`](#release)
+* [`repos`](#repos)
+* [`key`](#key)
+* [`key_source`](#key_source)
+* [`pin`](#pin)
 
-##### <a name="-erlang--repo--apt--erlang_solutions--ensure"></a>`ensure`
+##### <a name="ensure"></a>`ensure`
 
 Data type: `String`
 
@@ -190,23 +190,23 @@ Data type: `String`
 
 Default value: `$erlang::repo::apt::ensure`
 
-##### <a name="-erlang--repo--apt--erlang_solutions--location"></a>`location`
+##### <a name="location"></a>`location`
 
 Data type: `String`
 
 
 
-Default value: `'https://packages.erlang-solutions.com/debian'`
+Default value: `"https://binaries2.erlang-solutions.com/${(downcase($facts['os']['distro']['id']))}"`
 
-##### <a name="-erlang--repo--apt--erlang_solutions--release"></a>`release`
+##### <a name="release"></a>`release`
 
 Data type: `String`
 
 
 
-Default value: `downcase($facts['os']['distro']['codename'])`
+Default value: `"${downcase($facts['os']['distro']['codename'])}-esl-erlang-25"`
 
-##### <a name="-erlang--repo--apt--erlang_solutions--repos"></a>`repos`
+##### <a name="repos"></a>`repos`
 
 Data type: `String`
 
@@ -214,23 +214,23 @@ Data type: `String`
 
 Default value: `'contrib'`
 
-##### <a name="-erlang--repo--apt--erlang_solutions--key"></a>`key`
+##### <a name="key"></a>`key`
 
 Data type: `String`
 
 
 
-Default value: `'434975BD900CCBE4F7EE1B1ED208507CA14F4FCA'`
+Default value: `'26F8ADE7441C97EBE03DFEEA218B8A806CEFF98B'`
 
-##### <a name="-erlang--repo--apt--erlang_solutions--key_source"></a>`key_source`
+##### <a name="key_source"></a>`key_source`
 
 Data type: `String`
 
 
 
-Default value: `'https://packages.erlang-solutions.com/debian/erlang_solutions.asc'`
+Default value: `'https://binaries2.erlang-solutions.com/GPG-KEY-pmanager.asc'`
 
-##### <a name="-erlang--repo--apt--erlang_solutions--pin"></a>`pin`
+##### <a name="pin"></a>`pin`
 
 Data type: `Optional[Variant[Numeric, String]]`
 
@@ -238,7 +238,7 @@ Data type: `Optional[Variant[Numeric, String]]`
 
 Default value: `$erlang::package_apt_pin`
 
-### <a name="erlang--repo--yum"></a>`erlang::repo::yum`
+### <a name="erlangrepoyum"></a>`erlang::repo::yum`
 
 erlang yum repo
 
@@ -246,10 +246,10 @@ erlang yum repo
 
 The following parameters are available in the `erlang::repo::yum` class:
 
-* [`ensure`](#-erlang--repo--yum--ensure)
-* [`source`](#-erlang--repo--yum--source)
+* [`ensure`](#ensure)
+* [`source`](#source)
 
-##### <a name="-erlang--repo--yum--ensure"></a>`ensure`
+##### <a name="ensure"></a>`ensure`
 
 Data type: `String`
 
@@ -257,7 +257,7 @@ Data type: `String`
 
 Default value: `$erlang::repo_ensure`
 
-##### <a name="-erlang--repo--yum--source"></a>`source`
+##### <a name="source"></a>`source`
 
 Data type: `Erlang::RepoSource`
 
@@ -265,11 +265,11 @@ Data type: `Erlang::RepoSource`
 
 Default value: `$erlang::repo_source`
 
-### <a name="erlang--repo--yum--epel"></a>`erlang::repo::yum::epel`
+### <a name="erlangrepoyumepel"></a>`erlang::repo::yum::epel`
 
 Erlang packagecloud yum repo
 
-### <a name="erlang--repo--yum--erlang_solutions"></a>`erlang::repo::yum::erlang_solutions`
+### <a name="erlangrepoyumerlang_solutions"></a>`erlang::repo::yum::erlang_solutions`
 
 Erlang packagecloud yum repo
 
@@ -277,11 +277,11 @@ Erlang packagecloud yum repo
 
 The following parameters are available in the `erlang::repo::yum::erlang_solutions` class:
 
-* [`ensure`](#-erlang--repo--yum--erlang_solutions--ensure)
-* [`baseurl`](#-erlang--repo--yum--erlang_solutions--baseurl)
-* [`gpgkey`](#-erlang--repo--yum--erlang_solutions--gpgkey)
+* [`ensure`](#ensure)
+* [`baseurl`](#baseurl)
+* [`gpgkey`](#gpgkey)
 
-##### <a name="-erlang--repo--yum--erlang_solutions--ensure"></a>`ensure`
+##### <a name="ensure"></a>`ensure`
 
 Data type: `String`
 
@@ -289,7 +289,7 @@ Data type: `String`
 
 Default value: `$erlang::repo::yum::ensure`
 
-##### <a name="-erlang--repo--yum--erlang_solutions--baseurl"></a>`baseurl`
+##### <a name="baseurl"></a>`baseurl`
 
 Data type: `String`
 
@@ -297,7 +297,7 @@ Data type: `String`
 
 Default value: `"https://packages.erlang-solutions.com/rpm/centos/\$releasever/\$basearch"`
 
-##### <a name="-erlang--repo--yum--erlang_solutions--gpgkey"></a>`gpgkey`
+##### <a name="gpgkey"></a>`gpgkey`
 
 Data type: `String`
 
@@ -305,7 +305,7 @@ Data type: `String`
 
 Default value: `'https://packages.erlang-solutions.com/rpm/erlang_solutions.asc'`
 
-### <a name="erlang--repo--yum--packagecloud"></a>`erlang::repo::yum::packagecloud`
+### <a name="erlangrepoyumpackagecloud"></a>`erlang::repo::yum::packagecloud`
 
 Erlang packagecloud yum repo
 
@@ -313,11 +313,11 @@ Erlang packagecloud yum repo
 
 The following parameters are available in the `erlang::repo::yum::packagecloud` class:
 
-* [`ensure`](#-erlang--repo--yum--packagecloud--ensure)
-* [`baseurl`](#-erlang--repo--yum--packagecloud--baseurl)
-* [`gpgkey`](#-erlang--repo--yum--packagecloud--gpgkey)
+* [`ensure`](#ensure)
+* [`baseurl`](#baseurl)
+* [`gpgkey`](#gpgkey)
 
-##### <a name="-erlang--repo--yum--packagecloud--ensure"></a>`ensure`
+##### <a name="ensure"></a>`ensure`
 
 Data type: `String`
 
@@ -325,7 +325,7 @@ Data type: `String`
 
 Default value: `$erlang::repo::yum::ensure`
 
-##### <a name="-erlang--repo--yum--packagecloud--baseurl"></a>`baseurl`
+##### <a name="baseurl"></a>`baseurl`
 
 Data type: `String`
 
@@ -333,7 +333,7 @@ Data type: `String`
 
 Default value: `"https://packagecloud.io/rabbitmq/erlang/el/${$facts['os']['release']['major']}/\$basearch"`
 
-##### <a name="-erlang--repo--yum--packagecloud--gpgkey"></a>`gpgkey`
+##### <a name="gpgkey"></a>`gpgkey`
 
 Data type: `String`
 
@@ -343,7 +343,7 @@ Default value: `'https://packagecloud.io/rabbitmq/erlang/gpgkey'`
 
 ## Data types
 
-### <a name="Erlang--RepoSource"></a>`Erlang::RepoSource`
+### <a name="erlangreposource"></a>`Erlang::RepoSource`
 
 Options for what Erlang package repository to be configured on the system.
 This type defines the union of all possible options for both Apt and Yum repos.
@@ -358,5 +358,9 @@ For CentOS/RHEL the choices for `repo_source` are:
  - `'erlang_solutions'`
  - `'packagecloud'` (default)
 
-Alias of `Enum['epel', 'erlang_solutions', 'packagecloud']`
+Alias of
+
+```puppet
+Enum['epel', 'erlang_solutions', 'packagecloud']
+```
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -7,17 +7,17 @@
 ### Classes
 
 * [`erlang`](#erlang): Manages the Erlang repository and package installation.
-* [`erlang::repo`](#erlangrepo): Class that manages the erlang repo
-* [`erlang::repo::apt`](#erlangrepoapt): erlang apt repo
-* [`erlang::repo::apt::erlang_solutions`](#erlangrepoapterlang_solutions): erlang erlang_solutions apt repo
-* [`erlang::repo::yum`](#erlangrepoyum): erlang yum repo
-* [`erlang::repo::yum::epel`](#erlangrepoyumepel): Erlang packagecloud yum repo
-* [`erlang::repo::yum::erlang_solutions`](#erlangrepoyumerlang_solutions): Erlang packagecloud yum repo
-* [`erlang::repo::yum::packagecloud`](#erlangrepoyumpackagecloud): Erlang packagecloud yum repo
+* [`erlang::repo`](#erlang--repo): Class that manages the erlang repo
+* [`erlang::repo::apt`](#erlang--repo--apt): erlang apt repo
+* [`erlang::repo::apt::erlang_solutions`](#erlang--repo--apt--erlang_solutions): erlang erlang_solutions apt repo
+* [`erlang::repo::yum`](#erlang--repo--yum): erlang yum repo
+* [`erlang::repo::yum::epel`](#erlang--repo--yum--epel): Erlang packagecloud yum repo
+* [`erlang::repo::yum::erlang_solutions`](#erlang--repo--yum--erlang_solutions): Erlang packagecloud yum repo
+* [`erlang::repo::yum::packagecloud`](#erlang--repo--yum--packagecloud): Erlang packagecloud yum repo
 
 ### Data types
 
-* [`Erlang::RepoSource`](#erlangreposource): Options for what Erlang package repository to be configured on the system. This type defines the union of all possible options for both Apt a
+* [`Erlang::RepoSource`](#Erlang--RepoSource): Options for what Erlang package repository to be configured on the system. This type defines the union of all possible options for both Apt a
 
 ## Classes
 
@@ -73,14 +73,14 @@ class { 'erlang':
 
 The following parameters are available in the `erlang` class:
 
-* [`package_name`](#package_name)
-* [`package_ensure`](#package_ensure)
-* [`package_apt_pin`](#package_apt_pin)
-* [`manage_repo`](#manage_repo)
-* [`repo_ensure`](#repo_ensure)
-* [`repo_source`](#repo_source)
+* [`package_name`](#-erlang--package_name)
+* [`package_ensure`](#-erlang--package_ensure)
+* [`package_apt_pin`](#-erlang--package_apt_pin)
+* [`manage_repo`](#-erlang--manage_repo)
+* [`repo_ensure`](#-erlang--repo_ensure)
+* [`repo_source`](#-erlang--repo_source)
 
-##### <a name="package_name"></a>`package_name`
+##### <a name="-erlang--package_name"></a>`package_name`
 
 Data type: `String`
 
@@ -88,7 +88,7 @@ Name of the erlang package to install
 
 Default value: `'erlang'`
 
-##### <a name="package_ensure"></a>`package_ensure`
+##### <a name="-erlang--package_ensure"></a>`package_ensure`
 
 Data type: `String`
 
@@ -96,23 +96,23 @@ Determines the ensure state of the package.  Set to installed by default, but co
 
 Default value: `'installed'`
 
-##### <a name="package_apt_pin"></a>`package_apt_pin`
+##### <a name="-erlang--package_apt_pin"></a>`package_apt_pin`
 
 Data type: `Optional[Variant[Numeric, String]]`
 
 Whether to pin the package to a particular source.
 
-Default value: ``undef``
+Default value: `undef`
 
-##### <a name="manage_repo"></a>`manage_repo`
+##### <a name="-erlang--manage_repo"></a>`manage_repo`
 
 Data type: `Boolean`
 
 Whether or not this class should manage the erlang repository.
 
-Default value: ``true``
+Default value: `true`
 
-##### <a name="repo_ensure"></a>`repo_ensure`
+##### <a name="-erlang--repo_ensure"></a>`repo_ensure`
 
 Data type: `String`
 
@@ -120,7 +120,7 @@ Determines the ensure state of the repo.
 
 Default value: `'present'`
 
-##### <a name="repo_source"></a>`repo_source`
+##### <a name="-erlang--repo_source"></a>`repo_source`
 
 Data type: `Erlang::RepoSource`
 
@@ -135,11 +135,11 @@ For CentOS/RHEL the choices for `repo_source` are:
 
 Default value: `'packagecloud'`
 
-### <a name="erlangrepo"></a>`erlang::repo`
+### <a name="erlang--repo"></a>`erlang::repo`
 
 Class that manages the erlang repo
 
-### <a name="erlangrepoapt"></a>`erlang::repo::apt`
+### <a name="erlang--repo--apt"></a>`erlang::repo::apt`
 
 erlang apt repo
 
@@ -147,10 +147,10 @@ erlang apt repo
 
 The following parameters are available in the `erlang::repo::apt` class:
 
-* [`ensure`](#ensure)
-* [`source`](#source)
+* [`ensure`](#-erlang--repo--apt--ensure)
+* [`source`](#-erlang--repo--apt--source)
 
-##### <a name="ensure"></a>`ensure`
+##### <a name="-erlang--repo--apt--ensure"></a>`ensure`
 
 Data type: `String`
 
@@ -158,7 +158,7 @@ Data type: `String`
 
 Default value: `$erlang::repo_ensure`
 
-##### <a name="source"></a>`source`
+##### <a name="-erlang--repo--apt--source"></a>`source`
 
 Data type: `Erlang::RepoSource`
 
@@ -166,7 +166,7 @@ Data type: `Erlang::RepoSource`
 
 Default value: `$erlang::repo_source`
 
-### <a name="erlangrepoapterlang_solutions"></a>`erlang::repo::apt::erlang_solutions`
+### <a name="erlang--repo--apt--erlang_solutions"></a>`erlang::repo::apt::erlang_solutions`
 
 erlang erlang_solutions apt repo
 
@@ -174,15 +174,15 @@ erlang erlang_solutions apt repo
 
 The following parameters are available in the `erlang::repo::apt::erlang_solutions` class:
 
-* [`ensure`](#ensure)
-* [`location`](#location)
-* [`release`](#release)
-* [`repos`](#repos)
-* [`key`](#key)
-* [`key_source`](#key_source)
-* [`pin`](#pin)
+* [`ensure`](#-erlang--repo--apt--erlang_solutions--ensure)
+* [`location`](#-erlang--repo--apt--erlang_solutions--location)
+* [`release`](#-erlang--repo--apt--erlang_solutions--release)
+* [`repos`](#-erlang--repo--apt--erlang_solutions--repos)
+* [`key`](#-erlang--repo--apt--erlang_solutions--key)
+* [`key_source`](#-erlang--repo--apt--erlang_solutions--key_source)
+* [`pin`](#-erlang--repo--apt--erlang_solutions--pin)
 
-##### <a name="ensure"></a>`ensure`
+##### <a name="-erlang--repo--apt--erlang_solutions--ensure"></a>`ensure`
 
 Data type: `String`
 
@@ -190,7 +190,7 @@ Data type: `String`
 
 Default value: `$erlang::repo::apt::ensure`
 
-##### <a name="location"></a>`location`
+##### <a name="-erlang--repo--apt--erlang_solutions--location"></a>`location`
 
 Data type: `String`
 
@@ -198,7 +198,7 @@ Data type: `String`
 
 Default value: `"https://binaries2.erlang-solutions.com/${(downcase($facts['os']['distro']['id']))}"`
 
-##### <a name="release"></a>`release`
+##### <a name="-erlang--repo--apt--erlang_solutions--release"></a>`release`
 
 Data type: `String`
 
@@ -206,7 +206,7 @@ Data type: `String`
 
 Default value: `"${downcase($facts['os']['distro']['codename'])}-esl-erlang-25"`
 
-##### <a name="repos"></a>`repos`
+##### <a name="-erlang--repo--apt--erlang_solutions--repos"></a>`repos`
 
 Data type: `String`
 
@@ -214,7 +214,7 @@ Data type: `String`
 
 Default value: `'contrib'`
 
-##### <a name="key"></a>`key`
+##### <a name="-erlang--repo--apt--erlang_solutions--key"></a>`key`
 
 Data type: `String`
 
@@ -222,7 +222,7 @@ Data type: `String`
 
 Default value: `'26F8ADE7441C97EBE03DFEEA218B8A806CEFF98B'`
 
-##### <a name="key_source"></a>`key_source`
+##### <a name="-erlang--repo--apt--erlang_solutions--key_source"></a>`key_source`
 
 Data type: `String`
 
@@ -230,7 +230,7 @@ Data type: `String`
 
 Default value: `'https://binaries2.erlang-solutions.com/GPG-KEY-pmanager.asc'`
 
-##### <a name="pin"></a>`pin`
+##### <a name="-erlang--repo--apt--erlang_solutions--pin"></a>`pin`
 
 Data type: `Optional[Variant[Numeric, String]]`
 
@@ -238,7 +238,7 @@ Data type: `Optional[Variant[Numeric, String]]`
 
 Default value: `$erlang::package_apt_pin`
 
-### <a name="erlangrepoyum"></a>`erlang::repo::yum`
+### <a name="erlang--repo--yum"></a>`erlang::repo::yum`
 
 erlang yum repo
 
@@ -246,10 +246,10 @@ erlang yum repo
 
 The following parameters are available in the `erlang::repo::yum` class:
 
-* [`ensure`](#ensure)
-* [`source`](#source)
+* [`ensure`](#-erlang--repo--yum--ensure)
+* [`source`](#-erlang--repo--yum--source)
 
-##### <a name="ensure"></a>`ensure`
+##### <a name="-erlang--repo--yum--ensure"></a>`ensure`
 
 Data type: `String`
 
@@ -257,7 +257,7 @@ Data type: `String`
 
 Default value: `$erlang::repo_ensure`
 
-##### <a name="source"></a>`source`
+##### <a name="-erlang--repo--yum--source"></a>`source`
 
 Data type: `Erlang::RepoSource`
 
@@ -265,11 +265,11 @@ Data type: `Erlang::RepoSource`
 
 Default value: `$erlang::repo_source`
 
-### <a name="erlangrepoyumepel"></a>`erlang::repo::yum::epel`
+### <a name="erlang--repo--yum--epel"></a>`erlang::repo::yum::epel`
 
 Erlang packagecloud yum repo
 
-### <a name="erlangrepoyumerlang_solutions"></a>`erlang::repo::yum::erlang_solutions`
+### <a name="erlang--repo--yum--erlang_solutions"></a>`erlang::repo::yum::erlang_solutions`
 
 Erlang packagecloud yum repo
 
@@ -277,11 +277,11 @@ Erlang packagecloud yum repo
 
 The following parameters are available in the `erlang::repo::yum::erlang_solutions` class:
 
-* [`ensure`](#ensure)
-* [`baseurl`](#baseurl)
-* [`gpgkey`](#gpgkey)
+* [`ensure`](#-erlang--repo--yum--erlang_solutions--ensure)
+* [`baseurl`](#-erlang--repo--yum--erlang_solutions--baseurl)
+* [`gpgkey`](#-erlang--repo--yum--erlang_solutions--gpgkey)
 
-##### <a name="ensure"></a>`ensure`
+##### <a name="-erlang--repo--yum--erlang_solutions--ensure"></a>`ensure`
 
 Data type: `String`
 
@@ -289,7 +289,7 @@ Data type: `String`
 
 Default value: `$erlang::repo::yum::ensure`
 
-##### <a name="baseurl"></a>`baseurl`
+##### <a name="-erlang--repo--yum--erlang_solutions--baseurl"></a>`baseurl`
 
 Data type: `String`
 
@@ -297,7 +297,7 @@ Data type: `String`
 
 Default value: `"https://packages.erlang-solutions.com/rpm/centos/\$releasever/\$basearch"`
 
-##### <a name="gpgkey"></a>`gpgkey`
+##### <a name="-erlang--repo--yum--erlang_solutions--gpgkey"></a>`gpgkey`
 
 Data type: `String`
 
@@ -305,7 +305,7 @@ Data type: `String`
 
 Default value: `'https://packages.erlang-solutions.com/rpm/erlang_solutions.asc'`
 
-### <a name="erlangrepoyumpackagecloud"></a>`erlang::repo::yum::packagecloud`
+### <a name="erlang--repo--yum--packagecloud"></a>`erlang::repo::yum::packagecloud`
 
 Erlang packagecloud yum repo
 
@@ -313,11 +313,11 @@ Erlang packagecloud yum repo
 
 The following parameters are available in the `erlang::repo::yum::packagecloud` class:
 
-* [`ensure`](#ensure)
-* [`baseurl`](#baseurl)
-* [`gpgkey`](#gpgkey)
+* [`ensure`](#-erlang--repo--yum--packagecloud--ensure)
+* [`baseurl`](#-erlang--repo--yum--packagecloud--baseurl)
+* [`gpgkey`](#-erlang--repo--yum--packagecloud--gpgkey)
 
-##### <a name="ensure"></a>`ensure`
+##### <a name="-erlang--repo--yum--packagecloud--ensure"></a>`ensure`
 
 Data type: `String`
 
@@ -325,7 +325,7 @@ Data type: `String`
 
 Default value: `$erlang::repo::yum::ensure`
 
-##### <a name="baseurl"></a>`baseurl`
+##### <a name="-erlang--repo--yum--packagecloud--baseurl"></a>`baseurl`
 
 Data type: `String`
 
@@ -333,7 +333,7 @@ Data type: `String`
 
 Default value: `"https://packagecloud.io/rabbitmq/erlang/el/${$facts['os']['release']['major']}/\$basearch"`
 
-##### <a name="gpgkey"></a>`gpgkey`
+##### <a name="-erlang--repo--yum--packagecloud--gpgkey"></a>`gpgkey`
 
 Data type: `String`
 
@@ -343,7 +343,7 @@ Default value: `'https://packagecloud.io/rabbitmq/erlang/gpgkey'`
 
 ## Data types
 
-### <a name="erlangreposource"></a>`Erlang::RepoSource`
+### <a name="Erlang--RepoSource"></a>`Erlang::RepoSource`
 
 Options for what Erlang package repository to be configured on the system.
 This type defines the union of all possible options for both Apt and Yum repos.
@@ -358,9 +358,5 @@ For CentOS/RHEL the choices for `repo_source` are:
  - `'erlang_solutions'`
  - `'packagecloud'` (default)
 
-Alias of
-
-```puppet
-Enum['epel', 'erlang_solutions', 'packagecloud']
-```
+Alias of `Enum['epel', 'erlang_solutions', 'packagecloud']`
 

--- a/data/family/Debian.yaml
+++ b/data/family/Debian.yaml
@@ -1,2 +1,3 @@
 ---
 erlang::repo_source: 'erlang_solutions'
+erlang::package_name: 'esl-erlang'

--- a/manifests/repo/apt.pp
+++ b/manifests/repo/apt.pp
@@ -1,4 +1,7 @@
 # erlang apt repo
+#
+# @param ensure
+# @param source
 class erlang::repo::apt (
   String  $ensure = $erlang::repo_ensure,
   Erlang::RepoSource $source = $erlang::repo_source,

--- a/manifests/repo/apt/erlang_solutions.pp
+++ b/manifests/repo/apt/erlang_solutions.pp
@@ -1,12 +1,11 @@
 # erlang erlang_solutions apt repo
 class erlang::repo::apt::erlang_solutions (
   String $ensure = $erlang::repo::apt::ensure,
-  String $location    = 'https://packages.erlang-solutions.com/debian',
-  # trusty, xenial, bionic, etc
-  String $release     = downcase($facts['os']['distro']['codename']),
+  String $location    = "https://binaries2.erlang-solutions.com/${(downcase($facts['os']['distro']['id']))}",
+  String $release     = "${downcase($facts['os']['distro']['codename'])}-esl-erlang-25",
   String $repos       = 'contrib',
-  String $key         = '434975BD900CCBE4F7EE1B1ED208507CA14F4FCA',
-  String $key_source  = 'https://packages.erlang-solutions.com/debian/erlang_solutions.asc',
+  String $key         = '26F8ADE7441C97EBE03DFEEA218B8A806CEFF98B',
+  String $key_source  = 'https://binaries2.erlang-solutions.com/GPG-KEY-pmanager.asc',
   Optional[Variant[Numeric, String]] $pin = $erlang::package_apt_pin,
 ) inherits erlang {
   apt::source { 'erlang-erlang_solutions':

--- a/manifests/repo/apt/erlang_solutions.pp
+++ b/manifests/repo/apt/erlang_solutions.pp
@@ -1,4 +1,12 @@
 # erlang erlang_solutions apt repo
+#
+# @param ensure
+# @param location
+# @param release
+# @param repos
+# @param key
+# @param key_source
+# @param pin
 class erlang::repo::apt::erlang_solutions (
   String $ensure = $erlang::repo::apt::ensure,
   String $location    = "https://binaries2.erlang-solutions.com/${(downcase($facts['os']['distro']['id']))}",

--- a/manifests/repo/yum.pp
+++ b/manifests/repo/yum.pp
@@ -1,4 +1,7 @@
 # erlang yum repo
+#
+# @param ensure
+# @param source
 class erlang::repo::yum (
   String $ensure = $erlang::repo_ensure,
   Erlang::RepoSource $source = $erlang::repo_source,

--- a/manifests/repo/yum/erlang_solutions.pp
+++ b/manifests/repo/yum/erlang_solutions.pp
@@ -1,4 +1,8 @@
 # Erlang packagecloud yum repo
+#
+# @param ensure
+# @param baseurl
+# @param gpgkey
 class erlang::repo::yum::erlang_solutions (
   String $ensure  = $erlang::repo::yum::ensure,
   String $baseurl = "https://packages.erlang-solutions.com/rpm/centos/\$releasever/\$basearch",

--- a/manifests/repo/yum/packagecloud.pp
+++ b/manifests/repo/yum/packagecloud.pp
@@ -1,4 +1,8 @@
 # Erlang packagecloud yum repo
+#
+# @param ensure
+# @param baseurl
+# @param gpgkey
 class erlang::repo::yum::packagecloud (
   String $ensure  = $erlang::repo::yum::ensure,
   String $baseurl = "https://packagecloud.io/rabbitmq/erlang/el/${$facts['os']['release']['major']}/\$basearch",

--- a/metadata.json
+++ b/metadata.json
@@ -14,7 +14,7 @@
     },
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.13.0 < 9.0.0"
+      "version_requirement": ">= 4.13.0 < 10.0.0"
     }
   ],
   "operatingsystem_support": [

--- a/metadata.json
+++ b/metadata.json
@@ -42,7 +42,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 7.0.0 < 8.0.0"
+      "version_requirement": ">= 7.0.0 < 9.0.0"
     }
   ],
   "tags": [

--- a/metadata.json
+++ b/metadata.json
@@ -29,7 +29,8 @@
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
         "18.04",
-        "20.04"
+        "20.04",
+        "22.04"
       ]
     },
     {

--- a/metadata.json
+++ b/metadata.json
@@ -35,7 +35,9 @@
     {
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
-        "9"
+        "10",
+        "11",
+        "12"
       ]
     }
   ],

--- a/spec/acceptance/init_spec.rb
+++ b/spec/acceptance/init_spec.rb
@@ -170,7 +170,7 @@ describe 'erlang init:' do
 
       it_behaves_like 'an idempotent resource'
 
-      describe package('erlang') do
+      describe package('esl-erlang') do
         it { is_expected.to be_installed }
       end
     end
@@ -185,7 +185,7 @@ describe 'erlang init:' do
 
         it_behaves_like 'an idempotent resource'
 
-        describe package('erlang') do
+        describe package('esl-erlang') do
           it { is_expected.to be_installed }
         end
       end
@@ -203,7 +203,7 @@ describe 'erlang init:' do
 
         it_behaves_like 'an idempotent resource'
 
-        describe package('erlang') do
+        describe package('esl-erlang') do
           it { is_expected.not_to be_installed }
         end
       end

--- a/spec/classes/repo/apt/erlang_solutions_spec.rb
+++ b/spec/classes/repo/apt/erlang_solutions_spec.rb
@@ -21,7 +21,7 @@ describe 'erlang::repo::apt::erlang_solutions' do # rubocop:disable RSpec/EmptyE
                    'repos' => 'contrib',
                    'key' => {
                      'id' => '26F8ADE7441C97EBE03DFEEA218B8A806CEFF98B',
-                     'source' => 'https://binaries2.erlang-solutions.com/GPG-KEY-pmanager.as'
+                     'source' => 'https://binaries2.erlang-solutions.com/GPG-KEY-pmanager.asc'
                    })
           end
         end

--- a/spec/classes/repo/apt/erlang_solutions_spec.rb
+++ b/spec/classes/repo/apt/erlang_solutions_spec.rb
@@ -16,12 +16,12 @@ describe 'erlang::repo::apt::erlang_solutions' do # rubocop:disable RSpec/EmptyE
           it do
             is_expected.to contain_apt__source('erlang-erlang_solutions').
               with('ensure' => 'present',
-                   'location' => 'https://packages.erlang-solutions.com/debian',
-                   'release' => release,
+                   'location' => 'https://binaries2.erlang-solutions.com/debian',
+                   'release' => "#{release}-esl-erlang-25",
                    'repos' => 'contrib',
                    'key' => {
-                     'id' => '434975BD900CCBE4F7EE1B1ED208507CA14F4FCA',
-                     'source' => 'https://packages.erlang-solutions.com/debian/erlang_solutions.asc'
+                     'id' => '26F8ADE7441C97EBE03DFEEA218B8A806CEFF98B',
+                     'source' => 'https://binaries2.erlang-solutions.com/GPG-KEY-pmanager.as'
                    })
           end
         end

--- a/spec/classes/repo/apt/erlang_solutions_spec.rb
+++ b/spec/classes/repo/apt/erlang_solutions_spec.rb
@@ -9,7 +9,7 @@ describe 'erlang::repo::apt::erlang_solutions' do # rubocop:disable RSpec/EmptyE
       context "on #{os}" do
         let(:facts) { facts }
         let(:release) { facts[:os]['distro']['codename'] }
-        let(:name) { facts[:os]['name'] }
+        let(:name) { facts[:os]['name'].downcase }
 
         it { is_expected.to compile.with_all_deps }
 

--- a/spec/classes/repo/apt/erlang_solutions_spec.rb
+++ b/spec/classes/repo/apt/erlang_solutions_spec.rb
@@ -9,6 +9,7 @@ describe 'erlang::repo::apt::erlang_solutions' do # rubocop:disable RSpec/EmptyE
       context "on #{os}" do
         let(:facts) { facts }
         let(:release) { facts[:os]['distro']['codename'] }
+        let(:name) { facts[:os]['name'] }
 
         it { is_expected.to compile.with_all_deps }
 
@@ -16,7 +17,7 @@ describe 'erlang::repo::apt::erlang_solutions' do # rubocop:disable RSpec/EmptyE
           it do
             is_expected.to contain_apt__source('erlang-erlang_solutions').
               with('ensure' => 'present',
-                   'location' => 'https://binaries2.erlang-solutions.com/debian',
+                   'location' => "https://binaries2.erlang-solutions.com/#{name}",
                    'release' => "#{release}-esl-erlang-25",
                    'repos' => 'contrib',
                    'key' => {


### PR DESCRIPTION
#### Pull Request (PR) description

This PR implements support for Debian > 9 and Ubuntu > 18, `puppetlabs/stdlib` 9.x and Puppet 8.

#### This Pull Request (PR) fixes the following issues

Fixes #24 