### PR TITLE
Drop debian 9 support

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -31,12 +31,6 @@
         "18.04",
         "20.04"
       ]
-    },
-    {
-      "operatingsystem": "Debian",
-      "operatingsystemrelease": [
-        "9"
-      ]
     }
   ],
   "requirements": [


### PR DESCRIPTION
tests for other OS fail, will be fixed in #22
debian 10 and 11 will be readded later. see #27 for tracking